### PR TITLE
Make the comments resizable

### DIFF
--- a/public/secret-dj/styles.css
+++ b/public/secret-dj/styles.css
@@ -133,6 +133,7 @@ hr {
 iframe.comments {
 	height: 50vh;
 	border: 1px dashed;
+	resize: both;
 }
 
 .new-post-poster-label,

--- a/public/secret-dj/styles.css
+++ b/public/secret-dj/styles.css
@@ -190,6 +190,7 @@ td.post-poster {
 
 table.post-table {
 	border: none;
+	width: 100%;
 }
 
 td.post-poster {

--- a/public/secret-dj/styles.css
+++ b/public/secret-dj/styles.css
@@ -34,10 +34,6 @@ a {
 	color: green;
 }
 
-.embed {
-	width: 50%;
-}
-
 .description {
 	white-space: pre-wrap;
 	overflow-wrap: anywhere;
@@ -56,12 +52,18 @@ a {
 	margin-top: 0.5em;
 }
 
-@media only screen and (max-width: 700px) {
-	.embed,
-	form {
-		width: 100% !important;
-		box-sizing: border-box;
-	}
+/* This is the body that is not the comment box */
+body:not(:has(> h1.box-name)) {
+	max-width: 550px;
+	margin: 0 auto 0 auto;
+	padding: 8px;
+}
+
+.embed,
+textarea,
+form {
+	width: 100%;
+	box-sizing: border-box;
 }
 
 input:not([type="checkbox"]):not([type="number"]) {
@@ -74,9 +76,7 @@ input:not([type="checkbox"]):not([type="number"]) {
 }
 
 textarea {
-	width: 100%;
-	box-sizing: border-box;
-	aspect-ratio: 1.618/0.25;
+	aspect-ratio: 1.618/0.125;
 }
 
 table,
@@ -95,7 +95,6 @@ td {
 form {
 	margin: 8px 0;
 	padding: 8px;
-	width: 300px;
 	border: 1px dashed;
 }
 

--- a/src/auth/routers/views.ts
+++ b/src/auth/routers/views.ts
@@ -50,7 +50,7 @@ export const views = express()
 		} catch {
 			return res.render("pages/authorize", {
 				query: req.query,
-				error: "that token was not correct or was expired",
+				error: "that password was not correct. it may be expired or already used",
 				Config,
 			});
 		}

--- a/src/auth/schemas.ts
+++ b/src/auth/schemas.ts
@@ -9,7 +9,7 @@ export type LoginPayload = z.infer<typeof loginPayloadSchema>;
 
 export const authorizePayloadSchema = z.object({
 	email: emailSchema,
-	token: z.string().max(Config.DEFAULT_MAX_LENGTH),
+	token: z.string().trim().max(Config.DEFAULT_MAX_LENGTH),
 });
 
 export type AuthorizePayload = z.infer<typeof authorizePayloadSchema>;

--- a/views/pages/secret-dj/game.ejs
+++ b/views/pages/secret-dj/game.ejs
@@ -29,6 +29,7 @@
 			</div>
 
 			<div>
+				<hr />
 				<h3>participants</h3>
 				<%- include('../../partials/secret-dj/entry-table'); %>
 			</div>

--- a/views/partials/secret-dj/game/sign-up.ejs
+++ b/views/partials/secret-dj/game/sign-up.ejs
@@ -70,7 +70,7 @@
 
 		<label for="rule-<%=i+1%>">rule <%=season.ruleCount > 1 ? i + 1 : ''%></label>
 
-		<textarea name="rules[]" type="text" id="rule-<%=i+1%>" maxlength="<%=Config.DESCRIPTION_MAX_LENGTH%>">
+		<textarea name="rules[]" type="text" id="rule-<%=i+1%>" required maxlength="<%=Config.DESCRIPTION_MAX_LENGTH%>">
 <%= currentRule %></textarea
 		>
 		<% } %>


### PR DESCRIPTION
- rules are required in the form
- comments are resizable
- forms and embeds are width: 100%
- the main content is horizontally centered
- the main content has a max-width: 550px
- UNRELATED: sneaking in a token `.trim()` because i think people are having trouble with copy and paste

<img width="1680" alt="image" src="https://github.com/braxtonhall/bobs-server/assets/35436247/e982b429-dda7-42c2-b533-3c5a7e26eca6">
<img width="1680" alt="image" src="https://github.com/braxtonhall/bobs-server/assets/35436247/9f3cf988-35d1-481d-b741-de68f81183eb">

mobile view looks the same. the nice thing about this is that it removes the media query. the mobile view and the desktop view are the same style