### PR TITLE
Don't send so much data back through the action API

### DIFF
--- a/src/toolbox/routers/api.ts
+++ b/src/toolbox/routers/api.ts
@@ -80,7 +80,7 @@ const act = (behaviour: Behaviour) => async (req: Request, res: Response) =>
 			hashString(req.ip ?? ""),
 		),
 	)
-		.with(Some(P.select()), (value) => res.send(value))
+		.with(Some(P.select()), ({ value }) => res.send({ value }))
 		.otherwise(() => res.sendStatus(404));
 
 const countersApi = express()


### PR DESCRIPTION
I realised we were sending the entire action object from the database ALONG with its counter and owner information over the wire.

The PR reduces the data sent to just the counter value