### PR TITLE
Reduce spam login attempts

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -41,5 +41,6 @@ export default z
 		MAX_COUNTER_IMG_WIDTH: z.coerce.number().positive().default(800),
 		DEFAULT_COUNTER_IMG_HEIGHT: z.coerce.number().positive().default(100),
 		MAX_COUNTER_IMG_HEIGHT: z.coerce.number().positive().default(400),
+		MAX_ACTIVE_LOGIN_TOKENS: z.coerce.number().int().positive().default(3),
 	})
 	.parse(process.env);

--- a/src/auth/operations.ts
+++ b/src/auth/operations.ts
@@ -181,8 +181,18 @@ export const completeVerification = async ({
 
 export const login = async ({ email: address, next }: { email: string; next?: string }) => {
 	await transaction(async () => {
-		const temporaryToken = randomUUID();
 		const expiration = DateTime.now().plus({ minute: Config.LOGIN_TOKEN_EXPIRATION_MIN }).toJSDate();
+		const existing = await db.token.count({
+			where: {
+				type: TokenType.LOGIN,
+				expiration: { gte: expiration },
+				email: { address },
+			},
+		});
+		if (existing > Config.MAX_ACTIVE_LOGIN_TOKENS) {
+			throw new Error("Too many active login tokens");
+		}
+		const temporaryToken = randomUUID();
 		const { email } = await db.token.create({
 			data: {
 				type: TokenType.LOGIN,

--- a/src/auth/routers/views.ts
+++ b/src/auth/routers/views.ts
@@ -4,6 +4,7 @@ import Config from "../../Config";
 import { checkLoggedIn } from "../middlewares/authenticate";
 import { authorizePayloadSchema } from "../schemas";
 import { Duration } from "luxon";
+import slowDown from "express-slow-down";
 
 const tokenMaxAge = Duration.fromObject({ hour: Config.API_TOKEN_EXPIRATION_HOURS }).toMillis();
 
@@ -27,16 +28,29 @@ export const views = express()
 		}
 	})
 	.get("/login", checkLoggedIn, (req, res) => res.render("pages/login", { query: req.query, Config }))
-	.post("/login", checkLoggedIn, async (req, res) => {
-		const email: string = req.body.email;
-		await login({
-			email,
-			next: typeof req.body.next === "string" ? req.body.next : undefined,
-		}).catch(console.error);
-		return res.redirect(
-			`/authorize?${new URLSearchParams({ email, ...(req.body.next && { next: req.body.next }) })}`,
-		);
-	})
+	.post(
+		"/login",
+		slowDown({
+			windowMs: 15 * 60 * 1000, // 15 minutes
+			delayAfter: 2, // Allow 2 requests per 15 minutes.
+			delayMs: (hits) => hits * 1000, // Add 1s of delay to every request after the 2nd one.
+		}),
+		checkLoggedIn,
+		async (req, res) => {
+			const email: string = req.body.email;
+			try {
+				await login({
+					email,
+					next: typeof req.body.next === "string" ? req.body.next : undefined,
+				});
+				return res.redirect(
+					`/authorize?${new URLSearchParams({ email, ...(req.body.next && { next: req.body.next }) })}`,
+				);
+			} catch (error) {
+				return res.sendStatus(400);
+			}
+		},
+	)
 	.get("/authorize", checkLoggedIn, async (req, res) => {
 		const result = authorizePayloadSchema.safeParse(req.query);
 		if (!result.success) {

--- a/src/auth/routers/views.ts
+++ b/src/auth/routers/views.ts
@@ -5,6 +5,7 @@ import { checkLoggedIn } from "../middlewares/authenticate";
 import { authorizePayloadSchema } from "../schemas";
 import { Duration } from "luxon";
 import slowDown from "express-slow-down";
+import { emailSchema } from "../../toolbox/schema/email";
 
 const tokenMaxAge = Duration.fromObject({ hour: Config.API_TOKEN_EXPIRATION_HOURS }).toMillis();
 
@@ -37,8 +38,8 @@ export const views = express()
 		}),
 		checkLoggedIn,
 		async (req, res) => {
-			const email: string = req.body.email;
 			try {
+				const email = emailSchema.parse(req.body.email);
 				await login({
 					email,
 					next: typeof req.body.next === "string" ? req.body.next : undefined,


### PR DESCRIPTION
1. only allow 3 active login attempts at a time
2. validate that the email is indeed an email when we get it from user at POST /login
3. copy/pasta slowdown to both "subscribe" and "login" routes